### PR TITLE
Debug/kaleb coberly/test optional ref to checkout

### DIFF
--- a/.github/workflows/PR_CI_CD.yml
+++ b/.github/workflows/PR_CI_CD.yml
@@ -13,7 +13,8 @@ jobs:
 
   ci-cd:
     needs: close-external-prs
-    uses: crickets-and-comb/reference_package/.github/workflows/CI_CD.yml@main
+    # TODO: SWITCH BACK TO MAIN, here and in .gitmodules.
+    uses: crickets-and-comb/reference_package/.github/workflows/CI_CD.yml@bugfix/KalebCoberly/checkout_PR_ref
     with:
       TEST_OR_PROD: 'dev'
     secrets:

--- a/.github/workflows/PR_CI_CD.yml
+++ b/.github/workflows/PR_CI_CD.yml
@@ -14,7 +14,7 @@ jobs:
   ci-cd:
     needs: close-external-prs
     # TODO: SWITCH BACK TO MAIN.
-    uses: crickets-and-comb/reference_package/.github/workflows/CI_CD.yml@bugfix/KalebCoberly/checkout_PR_ref
+    uses: crickets-and-comb/reference_package/.github/workflows/CI_CD.yml@main
     with:
       TEST_OR_PROD: 'dev'
     secrets:

--- a/.github/workflows/PR_CI_CD.yml
+++ b/.github/workflows/PR_CI_CD.yml
@@ -13,7 +13,7 @@ jobs:
 
   ci-cd:
     needs: close-external-prs
-    # TODO: SWITCH BACK TO MAIN, here and in .gitmodules.
+    # TODO: SWITCH BACK TO MAIN.
     uses: crickets-and-comb/reference_package/.github/workflows/CI_CD.yml@bugfix/KalebCoberly/checkout_PR_ref
     with:
       TEST_OR_PROD: 'dev'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "shared"]
 	path = shared
 	url = https://github.com/crickets-and-comb/shared.git
-	branch = main
+	branch = bugfix/KalebCoberly/checkout_PR_ref

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "shared"]
 	path = shared
 	url = https://github.com/crickets-and-comb/shared.git
-	branch = bugfix/KalebCoberly/checkout_PR_ref
+	branch = main

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ When making smaller commits, you might just want to run some of the smaller comm
 
 ### Workflows: usage and limitations
 
-Using the workflows found in `.github/workflows`, QC, tests, builds, and deployment run on GitHub on certain events (e.g., pull requests, pushes to main, manual dispatches).
+QC, tests, builds, and deployment run on GitHub on certain events (e.g., pull requests, pushes to main, manual dispatches) using the workflows found in `.github/workflows`.
 
 The shared workflows (in the shared submodule at `shared/.github/workflows`) are reusable workflows, meaning they can can be called from within other workflows. See https://docs.github.com/en/actions/sharing-automations/reusing-workflows.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = reference_package
-version = 0.5.32
+version = 0.5.33
 description = A basic package setup with examples.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Updates `shared` commit hash to try not passing optional `REF_TO_CHECKOUT`.