### PR TITLE
Feature/kaleb coberly/try getting pr ref from within shared

### DIFF
--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -100,10 +100,7 @@ jobs:
 
   CI:
     name: QC and Tests
-    needs: validate-and-set-inputs
-    uses: crickets-and-comb/shared/.github/workflows/CI.yml@main
-    with:
-      REF_TO_CHECKOUT: ${{ needs.validate-and-set-inputs.outputs.REF_TO_CHECKOUT }}
+    uses: crickets-and-comb/shared/.github/workflows/CI.yml@feature/KalebCoberly/try_getting_PR_ref_from_within_shared
     secrets:
       CHECKOUT_SHARED: ${{ secrets.CHECKOUT_SHARED }}
       SAFETY_API_KEY: ${{ secrets.SAFETY_API_KEY }}

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -14,11 +14,6 @@ on:
         description: 'Python version to build with. Does not set matrix for QC and testing; just sets version for build jobs.'
         type: string
         default: "3.12"
-      REF_TO_CHECKOUT:
-        description: "The git ref to checkout."
-        required: false
-        default: "refs/heads/main"
-        type: string
       TEST_OR_PROD:
         description: 'Publish to test or prod? Default ("dev") skips publishing except on push to main, which publishes to test.'
         type: string
@@ -26,11 +21,6 @@ on:
 
   workflow_call:
     inputs:
-      REF_TO_CHECKOUT:
-        description: "The git ref to checkout."
-        required: false
-        default: "refs/heads/main"
-        type: string
       TEST_OR_PROD:
         description: 'Publish to test or prod? Default ("dev") skips publishing except on push to main, which publishes to test.'
         type: string
@@ -51,7 +41,6 @@ env:
   CONDA_VERSION: latest
   PACKAGE_TEST_WAIT_TIME: 120
   PYTHON_BUILD_VERSION_DEFAULT: "3.12"
-  REF_TO_CHECKOUT_DEFAULT: "refs/heads/main"
 
 jobs:
   validate-and-set-inputs:
@@ -59,7 +48,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       PYTHON_BUILD_VERSION: ${{ steps.set-python-version.outputs.PYTHON_BUILD_VERSION }}
-      REF_TO_CHECKOUT: ${{ steps.validate-ref.outputs.REF_TO_CHECKOUT }}
       TEST_OR_PROD: ${{ steps.set-test.outputs.TEST_OR_PROD }}
 
     steps:
@@ -86,18 +74,6 @@ jobs:
             echo "TEST_OR_PROD=$TEST_OR_PROD" >> $GITHUB_OUTPUT
           fi
 
-      - name: Validate and set REF_TO_CHECKOUT
-        id: validate-ref
-        env:
-          REF_TO_CHECKOUT: ${{ inputs.REF_TO_CHECKOUT }}
-        run: |
-          if [[ -z "$REF_TO_CHECKOUT" ]]; then
-            echo "REF_TO_CHECKOUT is not set, using default: $REF_TO_CHECKOUT_DEFAULT"
-            REF_TO_CHECKOUT=$REF_TO_CHECKOUT_DEFAULT
-          fi
-          echo "Using REF_TO_CHECKOUT: $REF_TO_CHECKOUT"
-          echo "REF_TO_CHECKOUT=$REF_TO_CHECKOUT" >> $GITHUB_OUTPUT
-
   CI:
     name: QC and Tests
     uses: crickets-and-comb/shared/.github/workflows/CI.yml@feature/KalebCoberly/try_getting_PR_ref_from_within_shared
@@ -113,7 +89,6 @@ jobs:
       DIST_DIR: "dist"
       PYTHON_BUILD_VERSION: ${{ needs.validate-and-set-inputs.outputs.PYTHON_BUILD_VERSION }}
       PYTHON_PACKAGE_DIST_NAME: python-package-distributions
-      REF_TO_CHECKOUT: ${{ needs.validate-and-set-inputs.outputs.REF_TO_CHECKOUT }}
       # Allows a test build locally without uploading.
       UPLOAD_DIST: ${{ needs.validate-and-set-inputs.outputs.TEST_OR_PROD == 'test' || needs.validate-and-set-inputs.outputs.TEST_OR_PROD == 'prod' }}
     secrets:

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -76,7 +76,7 @@ jobs:
 
   CI:
     name: QC and Tests
-    uses: crickets-and-comb/shared/.github/workflows/CI.yml@feature/KalebCoberly/try_getting_PR_ref_from_within_shared
+    uses: crickets-and-comb/shared/.github/workflows/CI.yml@main
     secrets:
       CHECKOUT_SHARED: ${{ secrets.CHECKOUT_SHARED }}
       SAFETY_API_KEY: ${{ secrets.SAFETY_API_KEY }}

--- a/.github/workflows/PR_CI_CD.yml
+++ b/.github/workflows/PR_CI_CD.yml
@@ -15,7 +15,6 @@ jobs:
     needs: close-external-prs
     uses: crickets-and-comb/reference_package/.github/workflows/CI_CD.yml@feature/KalebCoberly/try_getting_PR_ref_from_within_shared
     with:
-      REF_TO_CHECKOUT: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number) }}
       TEST_OR_PROD: 'dev'
     secrets:
       CHECKOUT_SHARED: ${{ secrets.CHECKOUT_SHARED }}

--- a/.github/workflows/PR_CI_CD.yml
+++ b/.github/workflows/PR_CI_CD.yml
@@ -13,7 +13,7 @@ jobs:
 
   ci-cd:
     needs: close-external-prs
-    uses: crickets-and-comb/reference_package/.github/workflows/CI_CD.yml@feature/KalebCoberly/try_getting_PR_ref_from_within_shared
+    uses: crickets-and-comb/reference_package/.github/workflows/CI_CD.yml@main
     with:
       TEST_OR_PROD: 'dev'
     secrets:

--- a/.github/workflows/PR_CI_CD.yml
+++ b/.github/workflows/PR_CI_CD.yml
@@ -13,7 +13,7 @@ jobs:
 
   ci-cd:
     needs: close-external-prs
-    uses: crickets-and-comb/reference_package/.github/workflows/CI_CD.yml@main
+    uses: crickets-and-comb/reference_package/.github/workflows/CI_CD.yml@feature/KalebCoberly/try_getting_PR_ref_from_within_shared
     with:
       REF_TO_CHECKOUT: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number) }}
       TEST_OR_PROD: 'dev'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "shared"]
 	path = shared
 	url = https://github.com/crickets-and-comb/shared.git
-	branch = feature/KalebCoberly/try_getting_PR_ref_from_within_shared
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "shared"]
 	path = shared
 	url = https://github.com/crickets-and-comb/shared.git
-	branch = main
+	branch = feature/KalebCoberly/try_getting_PR_ref_from_within_shared

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = reference_package
-version = 0.5.36
+version = 0.5.37
 description = A basic package setup with examples.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Stop passing `REF_TO_CHECKOUT` and let `shared` workflows set it, since GitHub event context inherited in reusable workflows.