### PR TITLE
Bugfix/kaleb coberly/pin flake8 black

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,12 +44,12 @@ doc =
 
 qc =
     bandit
-    black<25.9.0
+    black
     black[jupyter]
     flake8
     flake8-annotations
     flake8-bandit
-    flake8-black
+    flake8-black>=0.4.0
     flake8-bugbear
     flake8-docstrings
     flake8-isort

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,6 @@ doc =
 qc =
     bandit
     black
-    black[jupyter]
     flake8
     flake8-annotations
     flake8-bandit

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = reference_package
-version = 0.5.41
+version = 0.5.42
 description = A basic package setup with examples.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Pins to `flake8-black` release that pins `black` to avoid breaking release.
Also removes unnecessary `flake8-black[jupyter]`.