### PR TITLE
nltk develop

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,8 @@ packages=find:
 install_requires =
     click
     comb_utils
+    # Until nltk 3.9.3 is released: https://github.com/nltk/nltk/pull/3503
+    nltk @ git+https://github.com/nltk/nltk.git@develop
     typeguard
 
     # Scientific Python SPEC-0000 support window: https://scientific-python.org/specs/spec-0000/#support-window

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = reference_package
-version = 0.7.5
+version = 0.7.6
 description = A basic package setup with examples.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Partially addresses https://github.com/crickets-and-comb/shared/issues/152
Pins to `nltk@develop` until 3.9.3 released to address CVE-2025-14009.
Updates `shared` Git submodule to ignore for now.